### PR TITLE
Build docs with julia 1.5

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: 1.3
+          version: 1.5
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Just committed to `gh-pages` to try [this](https://github.com/JuliaDocs/Documenter.jl/issues/1177#issuecomment-640998242) to fix the docs. Hopefully, this fixes the doc deployment.